### PR TITLE
Add parallel tool execution with concurrency controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,27 +36,35 @@ const newState = await agentMemory(
 );
 ```
 
-#### `executeTools(toolIntents, state, tools)`
+#### `executeTools(toolIntents, state, tools, options?)`
 
-Executes multiple tool intents and updates the state with results.
+Executes multiple tool intents (optionally in parallel) and returns the updated state alongside execution telemetry.
 
 **Parameters:**
 - `toolIntents`: `ToolIntent[]` - Array of tool intents to execute
 - `state`: `ThreadState` - Current thread state
 - `tools`: `Tool[]` - Array of available LangChain tools
+- `options?`: `ParallelExecutionOptions` - Optional configuration including `concurrency`, `onResult` callback, and `scheduler` hooks
 
-**Returns:** `Promise<ThreadState>` - Updated state with tool execution results
+**Returns:** `Promise<{ state: ThreadState; summary: ToolExecutionSummary }>` - Result containing the updated state plus execution summary metadata
 
 **Example:**
 ```typescript
 import { executeTools } from '@enso-labs/agent-core';
-import { Tool } from 'langchain/tools';
+import type { ParallelExecutionOptions } from '@enso-labs/agent-core';
 
 const toolIntents = [
-  { intent: 'search', args: { query: 'weather today' } }
+  { intent: 'web_search', args: { query: 'weather today' }, runMode: 'parallel' },
+  { intent: 'web_search', args: { query: 'sunset time' }, runMode: 'parallel' }
 ];
 
-const updatedState = await executeTools(toolIntents, currentState, availableTools);
+const options: ParallelExecutionOptions = {
+  concurrency: 2,
+  onResult: (result) => console.log('tool finished', result.intent.intent, result.status)
+};
+
+const { state: updatedState, summary } = await executeTools(toolIntents, currentState, availableTools, options);
+console.log(summary.successCount, summary.failureCount);
 ```
 
 #### `convertStateToXML(state)`
@@ -134,6 +142,9 @@ Response structure returned by `agentLoop()` containing:
 Structure for tool execution requests:
 - `intent`: string - Tool name/identifier
 - `args`: any - Tool arguments
+- `runMode?`: `'parallel' | 'sequential'` - Execution preference (defaults to sequential)
+- `priority?`: `number` - Optional scheduling priority (lower numbers execute sooner within a parallel batch)
+- `groupId?`: `string` - Identifier to batch related intents in the same parallel group
 
 ## Error Handling
 

--- a/docs/plans/parallel-tool-calls.md
+++ b/docs/plans/parallel-tool-calls.md
@@ -1,0 +1,111 @@
+# Parallel Tool Call Support Plan
+
+## Goals
+- Allow `executeTools` to execute multiple tool invocations concurrently when it is safe to do so.
+- Preserve deterministic state updates and backwards compatibility with existing sequential behaviour.
+- Provide hooks for future streaming/observability of parallel executions and partial failures.
+
+## Current State
+- `executeTools` in `src/index.ts` iterates sequentially over `toolIntents`, invoking each tool with `await` and mutating `state` after every call.
+- Tool failures are caught per-invocation and appended to the state as error events, but there is no differentiation between transient errors and missing tools.
+- Memory updates rely on `agentMemory`, which appends events to `state.thread.events` while carrying forward usage metadata.
+- Streaming mode relies on serial writes to the event stream; there is currently no facility to surface in-flight tool runs.
+
+## Key Challenges
+1. **State Mutation Ordering** – Running tools in parallel means we cannot rely on sequential `state = await agentMemory(...)` updates; we need a way to accumulate results and merge them afterwards.
+2. **Tool Dependency Handling** – Some tools may depend on the output of others. We need an API to mark intents that must remain sequential.
+3. **Error Aggregation** – We must surface which tool(s) failed without losing the ability to capture partial successes.
+4. **Resource Limits** – Allowing unbounded parallelism could overwhelm the host. We should support a configurable concurrency limit.
+
+## Proposed Design
+The design revolves around isolating side effects while a batch of tools runs, then replaying the successful results back through existing state-mutating utilities.
+
+1. **Execution Planner**
+   - Extend `ToolIntent` to accept optional metadata, e.g. `{ intent, args, runMode?: 'parallel' | 'sequential', priority?: number, groupId?: string }`.
+   - Default `runMode` to `sequential` for backwards compatibility; classifier can opt in to parallel for independent intents.
+   - `groupId` allows explicit grouping of intents that must run together (e.g., map-reduce patterns) while preserving the ability to batch unrelated calls.
+
+2. **Concurrency Controller**
+   - Implement `executeToolIntent(toolIntent, stateSnapshot, tools)` that returns `{ event, metadata, error }` without mutating shared state.
+   - Introduce a `runInBatches(intents, concurrency)` helper to process intents with `Promise.allSettled`, respecting `runMode`, `priority`, and `groupId`.
+   - Allow a new optional argument to `executeTools`: `{ concurrency?: number, scheduler?: SchedulerHooks }`, defaulting to `1` (sequential) until callers opt in.
+   - Use a `p-limit` style helper to bound in-flight executions; when concurrency is `1` the helper degenerates to the existing sequential path.
+
+3. **State Merge Strategy**
+   - After each batch, sort completed events by their original index (or explicit priority) to maintain deterministic ordering in `state.thread.events`.
+   - Apply `agentMemory` once per result using the new ordered list so that `usage` bookkeeping remains centralized.
+   - Ensure that the merge path is the single place where `state` is mutated, simplifying auditing and making it easier to add instrumentation.
+
+4. **Error Handling**
+   - Attach failure metadata including stack/trace when available and flag events with `status: 'error'`.
+   - Aggregate an overall `toolExecutionStatus` object (success count, failure count, failures[]) that `agentLoop` can log or return.
+   - Provide a hook (`scheduler?.onFailure`) so UI/observability layers can surface partial failures while other tools continue running.
+
+5. **Streaming Compatibility**
+   - Introduce an optional `onResult` callback that receives interim results as soon as a tool settles; this will be invoked from the `runInBatches` helper before merge.
+   - Ensure callback invocations occur in settlement order but are explicitly documented as potentially out-of-order relative to final state writes.
+
+6. **Backwards Compatibility**
+   - Preserve existing function signature for default behaviour; only parallel-aware callers need to pass options or flagged intents.
+   - Ensure unit tests continue to pass when `concurrency = 1`.
+   - Provide a runtime guard to detect if any `ToolIntent` opts into `parallel` while `executeTools` is running in environments that disallow concurrency and fall back to sequential execution with a warning event.
+
+## Implementation Steps
+1. **Type Updates**
+   - Update `ToolIntent` type definition to include optional `runMode`, `priority`, and `groupId`.
+   - Add a `ParallelExecutionOptions` interface that mirrors the new options for `executeTools` and can be shared with higher-level APIs.
+   - Document new fields in README and TypeDoc comments.
+
+2. **Utility Extraction**
+   - Refactor current `executeTools` loop into helper functions:
+     - `resolveTool(toolIntent, tools)` – validates existence and returns tool instance.
+     - `invokeTool(tool, args, abortSignal)` – wraps invocation with timing metadata and exposes cancellation for future streaming.
+     - `buildToolEvent(result)` – normalizes the shape used by `agentMemory` and consumers.
+
+3. **Parallel Execution Core**
+   - Implement `executeToolBatch(intents, state, tools, options)` using `Promise.allSettled` to gather results.
+   - Introduce a `scheduleIntents(intents, options)` planner that separates purely parallel groups from explicitly sequential segments.
+   - Create deterministic `mergeToolResults(state, results, agentMemory)` that replays events through `agentMemory` in intent order.
+   - Record metrics (counts, duration) via `options.scheduler?.onProgress?.(summary)`.
+
+4. **API Surface Adjustments**
+   - Allow `executeTools(toolIntents, state, tools, options?)` with optional `concurrency`, `onResult`, and `scheduler` callbacks.
+   - Update `agentLoop` and any callsites to pass through the new options while defaulting to sequential behaviour.
+   - Expose a top-level `createParallelScheduler` helper that can be reused by embedding applications to integrate with their tracing systems.
+
+5. **Testing & Validation**
+   - Add unit tests covering:
+     - Mixed sequential + parallel batches.
+     - Error propagation when a tool rejects.
+     - Concurrency limit enforcement (e.g., ensure only `n` invocations run at once using mock tools).
+     - Deterministic ordering of events in the state regardless of completion order.
+     - `onResult` callback ordering and idempotence when listeners throw.
+     - Fallback to sequential execution when concurrency is unsupported or dependencies require ordering.
+
+6. **Documentation**
+   - Update README usage examples to demonstrate opting into parallel execution.
+   - Provide migration notes explaining defaults and safety considerations.
+   - Add a troubleshooting section describing how to debug concurrency-related failures.
+
+7. **Rollout Strategy**
+   - Ship behind an opt-in feature flag for internal consumers first.
+   - Capture telemetry to confirm success/failure rate parity before enabling broadly.
+   - Publish a changelog entry summarizing behavioural changes and new configuration knobs.
+
+## Open Questions
+- Should we expose execution telemetry (start/end timestamps) on events or keep it internal until a telemetry subsystem exists?
+- Do we need to support true dependency graphs (DAG) now, or is staged batching sufficient?
+- How should we propagate partial tool results to streaming clients when `agentLoop` is in streaming mode?
+
+## Risk Register & Mitigations
+- **Race conditions in shared state** – Restrict all state mutations to the merge phase and add unit tests asserting deterministic event ordering.
+- **Tool implementations assuming sequential execution** – Provide feature flag fallbacks and a migration guide; surface warnings when tools request sequential mode.
+- **Resource exhaustion** – Default concurrency to 1 and require explicit opt-in; enforce an upper bound derived from configuration or environment heuristics.
+- **Debuggability of failures** – Enhance logging with per-intent identifiers and batch IDs so operators can correlate failures to specific tool runs.
+
+## Milestones & Rough Timeline
+1. **Week 1 – Foundations**: Type updates, helper extraction, and sequential regression tests.
+2. **Week 2 – Parallel core**: Implement scheduler/batching logic, add merge path, and land targeted unit tests.
+3. **Week 3 – Observability & Docs**: Wire optional callbacks, add README + migration notes, and run integration tests against representative tool suites.
+4. **Week 4 – Beta rollout**: Ship behind feature flag to internal agents, monitor telemetry, and gather feedback before public release.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@enso-labs/agent-core",
-  "version": "0.0.1-rc2",
+  "version": "0.0.1-rc6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@enso-labs/agent-core",
-      "version": "0.0.1-rc2",
+      "version": "0.0.1-rc6",
       "license": "ISC",
       "dependencies": {
         "@langchain/core": "^0.3.67",

--- a/src/entities/tool.ts
+++ b/src/entities/tool.ts
@@ -1,76 +1,84 @@
 // Define tool intent interfaces
-interface WeatherIntent {
-	intent: 'get_weather';
-	args: {location: string};
+export type ToolRunMode = 'parallel' | 'sequential';
+
+interface ParallelExecutionMetadata {
+        runMode?: ToolRunMode;
+        priority?: number;
+        groupId?: string;
 }
 
-interface StockIntent {
-	intent: 'get_stock_info';
-	args: {ticker: string};
+interface WeatherIntent extends ParallelExecutionMetadata {
+        intent: 'get_weather';
+        args: {location: string};
 }
 
-interface WebSearchIntent {
-	intent: 'web_search';
-	args: {query: string};
+interface StockIntent extends ParallelExecutionMetadata {
+        intent: 'get_stock_info';
+        args: {ticker: string};
 }
 
-interface MathIntent {
-	intent: 'math_calculator';
-	args: {expression: string};
+interface WebSearchIntent extends ParallelExecutionMetadata {
+        intent: 'web_search';
+        args: {query: string};
 }
 
-interface FileSearchIntent {
-	intent: 'file_search';
-	args: {pattern: string; directory?: string};
+interface MathIntent extends ParallelExecutionMetadata {
+        intent: 'math_calculator';
+        args: {expression: string};
 }
 
-interface ReadFileIntent {
-	intent: 'read_file';
-	args: {filepath: string};
+interface FileSearchIntent extends ParallelExecutionMetadata {
+        intent: 'file_search';
+        args: {pattern: string; directory?: string};
 }
 
-interface CreateFileIntent {
-	intent: 'create_file';
-	args: {filepath: string; content: string};
+interface ReadFileIntent extends ParallelExecutionMetadata {
+        intent: 'read_file';
+        args: {filepath: string};
 }
 
-interface GitStatusIntent {
-	intent: 'git_status';
-	args: Record<string, never>;
+interface CreateFileIntent extends ParallelExecutionMetadata {
+        intent: 'create_file';
+        args: {filepath: string; content: string};
 }
 
-interface PwdIntent {
-	intent: 'pwd';
-	args: Record<string, never>;
+interface GitStatusIntent extends ParallelExecutionMetadata {
+        intent: 'git_status';
+        args: Record<string, never>;
 }
 
-interface TerminalCommandIntent {
-	intent: 'terminal_command';
-	args: {command: string; timeout?: number};
+interface PwdIntent extends ParallelExecutionMetadata {
+        intent: 'pwd';
+        args: Record<string, never>;
 }
 
-interface NpmInfoIntent {
-	intent: 'npm_info';
-	args: {package: string};
+interface TerminalCommandIntent extends ParallelExecutionMetadata {
+        intent: 'terminal_command';
+        args: {command: string; timeout?: number};
 }
 
-interface NoIntent {
-	intent: 'none';
-	args: Record<string, never>;
+interface NpmInfoIntent extends ParallelExecutionMetadata {
+        intent: 'npm_info';
+        args: {package: string};
+}
+
+interface NoIntent extends ParallelExecutionMetadata {
+        intent: 'none';
+        args: Record<string, never>;
 }
 
 type ToolIntent =
-	| WeatherIntent
-	| StockIntent
-	| WebSearchIntent
-	| MathIntent
-	| FileSearchIntent
-	| ReadFileIntent
-	| CreateFileIntent
-	| GitStatusIntent
-	| PwdIntent
-	| TerminalCommandIntent
-	| NpmInfoIntent
-	| NoIntent;
+        | WeatherIntent
+        | StockIntent
+        | WebSearchIntent
+        | MathIntent
+        | FileSearchIntent
+        | ReadFileIntent
+        | CreateFileIntent
+        | GitStatusIntent
+        | PwdIntent
+        | TerminalCommandIntent
+        | NpmInfoIntent
+        | NoIntent;
 
-export type {ToolIntent};
+export type {ToolIntent, ParallelExecutionMetadata};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import type { ThreadState, AgentResponse } from "./entities/state.js";
 import { classifyIntent } from "./utils/classify.js";
 import { callModel } from "./utils/llm.js";
-import type { ToolIntent } from "./entities/tool.js";
+import type { ToolIntent, ToolRunMode } from "./entities/tool.js";
 import { Tool } from "langchain/tools";
 import { jsonHandler, streamHandler } from "./utils/stream.js";
 
@@ -50,53 +50,402 @@ type EventStatusOptions = {
 };
 
 function eventStatus({status}: EventStatusOptions = {}) {
-	const map: Record<string, {icon: string; label: string}> = {
-		error: {icon: '❌', label: 'error'},
-		success: {icon: '✅', label: 'success'},
-		pending: {icon: '⏳', label: 'pending'},
-		waiting_for_feedback: {icon: '🕒', label: 'waiting_for_feedback'},
-	};
-	const statusKey = status ?? '';
-	const {icon, label} = map[statusKey] || {icon: '❓', label: 'unknown'};
-	return {
-		icon,
-		status: label,
-	};
+        const map: Record<string, {icon: string; label: string}> = {
+                error: {icon: '❌', label: 'error'},
+                success: {icon: '✅', label: 'success'},
+                pending: {icon: '⏳', label: 'pending'},
+                waiting_for_feedback: {icon: '🕒', label: 'waiting_for_feedback'},
+        };
+        const statusKey = status ?? '';
+        const {icon, label} = map[statusKey] || {icon: '❓', label: 'unknown'};
+        return {
+                icon,
+                status: label,
+        };
+}
+
+type IndexedToolIntent = ToolIntent & { __index: number };
+
+export interface ToolExecutionFailure {
+        index: number;
+        intent: ToolIntent;
+        error: string;
+}
+
+export interface ToolExecutionResult {
+        index: number;
+        intent: ToolIntent;
+        status: 'success' | 'error';
+        content: string;
+        metadata: Record<string, any>;
+        error?: Error;
+        startedAt: number;
+        endedAt: number;
+}
+
+export interface ToolExecutionSummary {
+        total: number;
+        completed: number;
+        successCount: number;
+        failureCount: number;
+        failures: ToolExecutionFailure[];
+}
+
+export interface ToolExecutionProgress extends ToolExecutionSummary {}
+
+export interface SchedulerBatchContext {
+        batchId: string;
+        size: number;
+        mode: ToolRunMode;
+        groupId: string | null;
+}
+
+export interface SchedulerBatchResult extends SchedulerBatchContext {
+        durationMs: number;
+        results: ToolExecutionResult[];
+        summary: ToolExecutionSummary;
+}
+
+export interface SchedulerHooks {
+        onBatchStart?(context: SchedulerBatchContext): void | Promise<void>;
+        onBatchComplete?(result: SchedulerBatchResult): void | Promise<void>;
+        onFailure?(result: ToolExecutionResult): void | Promise<void>;
+        onProgress?(progress: ToolExecutionProgress): void | Promise<void>;
+}
+
+export interface ParallelExecutionOptions {
+        concurrency?: number;
+        onResult?(result: ToolExecutionResult): void | Promise<void>;
+        scheduler?: SchedulerHooks;
+}
+
+type ScheduledBatch = {
+        id: string;
+        mode: ToolRunMode;
+        groupId: string | null;
+        intents: IndexedToolIntent[];
+};
+
+const DEFAULT_CONCURRENCY = 1;
+
+async function safeInvoke<Args extends any[]>(
+        callback: ((...args: Args) => any) | undefined,
+        ...args: Args
+) {
+        if (!callback) {
+                return;
+        }
+
+        try {
+                await callback(...args);
+        } catch (error) {
+                console.warn('Parallel tool callback threw', error);
+        }
+}
+
+function resolveTool(toolIntent: ToolIntent, tools: Tool[]) {
+        const tool = tools.find(t => t.name === toolIntent.intent);
+        if (!tool) {
+                throw new Error(`Tool ${toolIntent.intent} not found`);
+        }
+        return tool;
+}
+
+async function invokeTool(tool: Tool, args: any) {
+        return tool.invoke(args);
+}
+
+async function executeToolIntent(
+        indexedIntent: IndexedToolIntent,
+        tools: Tool[],
+): Promise<ToolExecutionResult> {
+        const {__index, ...rest} = indexedIntent;
+        const baseIntent = rest as ToolIntent;
+
+        if (baseIntent.intent === 'none') {
+                return {
+                        index: __index,
+                        intent: baseIntent,
+                        status: 'success',
+                        content: '',
+                        metadata: eventStatus({status: 'success'}),
+                        startedAt: Date.now(),
+                        endedAt: Date.now(),
+                };
+        }
+
+        const startedAt = Date.now();
+        try {
+                const tool = resolveTool(baseIntent, tools);
+                const toolOutput = await invokeTool(tool, baseIntent.args);
+                const endedAt = Date.now();
+                return {
+                        index: __index,
+                        intent: baseIntent,
+                        status: 'success',
+                        content: toolOutput,
+                        metadata: {
+                                ...eventStatus({status: 'success'}),
+                                toolName: baseIntent.intent,
+                                durationMs: endedAt - startedAt,
+                        },
+                        startedAt,
+                        endedAt,
+                };
+        } catch (error) {
+                const endedAt = Date.now();
+                const err = error instanceof Error ? error : new Error('Unknown error');
+                const errorMessage = `Tool execution failed: ${err.message}`;
+                return {
+                        index: __index,
+                        intent: baseIntent,
+                        status: 'error',
+                        content: errorMessage,
+                        metadata: {
+                                ...eventStatus({status: 'error'}),
+                                toolName: baseIntent.intent,
+                                durationMs: endedAt - startedAt,
+                                errorName: err.name,
+                        },
+                        error: err,
+                        startedAt,
+                        endedAt,
+                };
+        }
+}
+
+function scheduleIntents(intents: IndexedToolIntent[]): ScheduledBatch[] {
+        const batches: ScheduledBatch[] = [];
+        let parallelBatch: ScheduledBatch | null = null;
+
+        intents.forEach((intent, idx) => {
+                const runMode: ToolRunMode = intent.runMode ?? 'sequential';
+                const groupId = intent.groupId ?? null;
+
+                if (runMode === 'parallel') {
+                        if (
+                                parallelBatch &&
+                                parallelBatch.mode === 'parallel' &&
+                                parallelBatch.groupId === groupId
+                        ) {
+                                parallelBatch.intents.push(intent);
+                        } else {
+                                if (parallelBatch) {
+                                        batches.push(parallelBatch);
+                                }
+                                parallelBatch = {
+                                        id: groupId ?? `parallel-${idx}`,
+                                        mode: 'parallel',
+                                        groupId,
+                                        intents: [intent],
+                                };
+                        }
+                } else {
+                        if (parallelBatch) {
+                                batches.push(parallelBatch);
+                                parallelBatch = null;
+                        }
+                        batches.push({
+                                id: `sequential-${idx}`,
+                                mode: 'sequential',
+                                groupId,
+                                intents: [intent],
+                        });
+                }
+        });
+
+        if (parallelBatch) {
+                batches.push(parallelBatch);
+        }
+
+        return batches;
+}
+
+function snapshotSummary(summary: ToolExecutionSummary): ToolExecutionSummary {
+        return {
+                total: summary.total,
+                completed: summary.completed,
+                successCount: summary.successCount,
+                failureCount: summary.failureCount,
+                failures: [...summary.failures],
+        };
+}
+
+async function settleIntent(
+        intent: IndexedToolIntent,
+        tools: Tool[],
+        summary: ToolExecutionSummary,
+        options: ParallelExecutionOptions,
+): Promise<ToolExecutionResult> {
+        const result = await executeToolIntent(intent, tools);
+
+        if (result.status === 'success') {
+                summary.successCount += 1;
+        } else {
+                summary.failureCount += 1;
+                summary.failures.push({
+                        index: result.index,
+                        intent: result.intent,
+                        error: result.error?.message ?? 'Unknown error',
+                });
+                await safeInvoke(options.scheduler?.onFailure, result);
+        }
+
+        summary.completed = summary.successCount + summary.failureCount;
+
+        await safeInvoke(options.onResult, result);
+        await safeInvoke(options.scheduler?.onProgress, snapshotSummary(summary));
+
+        return result;
+}
+
+async function runSequentialBatch(
+        batch: ScheduledBatch,
+        tools: Tool[],
+        summary: ToolExecutionSummary,
+        options: ParallelExecutionOptions,
+): Promise<ToolExecutionResult[]> {
+        const results: ToolExecutionResult[] = [];
+        for (const intent of batch.intents) {
+                const result = await settleIntent(intent, tools, summary, options);
+                if (result.intent.intent !== 'none') {
+                        results.push(result);
+                }
+        }
+        return results;
+}
+
+async function runParallelBatch(
+        batch: ScheduledBatch,
+        tools: Tool[],
+        summary: ToolExecutionSummary,
+        options: ParallelExecutionOptions,
+        concurrency: number,
+): Promise<ToolExecutionResult[]> {
+        const queue = [...batch.intents].sort((a, b) => {
+                const priorityA = a.priority ?? Number.POSITIVE_INFINITY;
+                const priorityB = b.priority ?? Number.POSITIVE_INFINITY;
+                if (priorityA !== priorityB) {
+                        return priorityA - priorityB;
+                }
+                return a.__index - b.__index;
+        });
+
+        const results: ToolExecutionResult[] = [];
+        const workers: Promise<void>[] = [];
+
+        const worker = async () => {
+                while (queue.length > 0) {
+                        const intent = queue.shift();
+                        if (!intent) {
+                                return;
+                        }
+                        const result = await settleIntent(intent, tools, summary, options);
+                        if (result.intent.intent !== 'none') {
+                                results.push(result);
+                        }
+                }
+        };
+
+        const workerCount = Math.max(1, Math.min(concurrency, queue.length));
+        for (let i = 0; i < workerCount; i += 1) {
+                workers.push(worker());
+        }
+
+        await Promise.all(workers);
+        return results;
 }
 
 export async function executeTools(
-	toolIntents: ToolIntent[],
-	state: ThreadState,
-	tools: Tool[],
-) {
-	// Execute all identified tools
-	for (const toolIntent of toolIntents) {
-		const {intent, args} = toolIntent;
+        toolIntents: ToolIntent[],
+        state: ThreadState,
+        tools: Tool[],
+        options: ParallelExecutionOptions = {},
+): Promise<{ state: ThreadState; summary: ToolExecutionSummary }>
+{
+        const scheduler = options.scheduler;
+        const configuredConcurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
+        const normalizedConcurrency = Number.isFinite(configuredConcurrency)
+                ? Math.max(1, Math.floor(configuredConcurrency))
+                : DEFAULT_CONCURRENCY;
 
-		if (intent === 'none') {
-			continue;
-		}
+        const actionableIntents = toolIntents
+                .map((intent, index) => ({...intent, __index: index}))
+                .filter(intent => intent.intent !== 'none');
 
-		// Check if tool exists in the tools object or handle special cases
-		let toolOutput: string;
-		let metadata: any = eventStatus({status: 'success'});
-		try {
-			const tool = tools.find(t => t.name === intent);
-			if (!tool) {
-				throw new Error(`Tool ${intent} not found`);
-			}
-			toolOutput = await tool.invoke(args);
+        const summary: ToolExecutionSummary = {
+                total: actionableIntents.length,
+                completed: 0,
+                successCount: 0,
+                failureCount: 0,
+                failures: [],
+        };
 
-			// Add tool execution as an event
-			state = await agentMemory(toolIntent, toolOutput, state, metadata);
-		} catch (error) {
-			const errorMessage = `Tool execution failed: ${
-				error instanceof Error ? error.message : 'Unknown error'
-			}`;
-			state = await agentMemory(toolIntent, errorMessage, state);
-		}
-	}
-	return state;
+        if (actionableIntents.length === 0) {
+                return {state, summary};
+        }
+
+        const batches = scheduleIntents(actionableIntents);
+        const containsParallel = actionableIntents.some(
+                intent => (intent.runMode ?? 'sequential') === 'parallel',
+        );
+        const parallelEnabled = normalizedConcurrency > 1;
+        const shouldWarnParallelDisabled = containsParallel && !parallelEnabled;
+
+        const allResults: ToolExecutionResult[] = [];
+
+        for (const batch of batches) {
+                const batchStart = Date.now();
+                await safeInvoke(scheduler?.onBatchStart, {
+                        batchId: batch.id,
+                        size: batch.intents.length,
+                        mode: batch.mode,
+                        groupId: batch.groupId,
+                });
+
+                let batchResults: ToolExecutionResult[] = [];
+
+                if (batch.mode === 'parallel' && parallelEnabled) {
+                        batchResults = await runParallelBatch(
+                                batch,
+                                tools,
+                                summary,
+                                options,
+                                normalizedConcurrency,
+                        );
+                } else {
+                        batchResults = await runSequentialBatch(batch, tools, summary, options);
+                }
+
+                allResults.push(...batchResults);
+
+                await safeInvoke(scheduler?.onBatchComplete, {
+                        batchId: batch.id,
+                        size: batch.intents.length,
+                        mode: batch.mode,
+                        groupId: batch.groupId,
+                        durationMs: Date.now() - batchStart,
+                        results: [...batchResults],
+                        summary: snapshotSummary(summary),
+                });
+        }
+
+        const orderedResults = allResults.sort((a, b) => a.index - b.index);
+
+        for (const result of orderedResults) {
+                state = await agentMemory(result.intent, result.content, state, result.metadata);
+        }
+
+        if (shouldWarnParallelDisabled) {
+                state = await agentMemory(
+                        'parallel_execution_warning',
+                        'Parallel tool intents requested but concurrency is disabled. Falling back to sequential execution.',
+                        state,
+                        eventStatus({status: 'waiting_for_feedback'}),
+                );
+        }
+
+        return {state, summary: snapshotSummary(summary)};
 }
 
 export function convertStateToXML(state: ThreadState): string {
@@ -150,8 +499,12 @@ export async function agentLoop({
 		tools,
 	);
 
-	// Execute all identified tools
-	state = await executeTools(toolIntents, state, tools);
+        // Execute all identified tools
+        const execution = await executeTools(toolIntents, state, tools);
+        state = execution.state;
+        if (execution.summary.failureCount > 0) {
+                console.warn('Tool execution failures detected', execution.summary.failures);
+        }
 
 	// Generate LLM response
 	const systemMessage = state.thread.systemMessage || 'You are a helpful AI assistant.';

--- a/test/execute-tools.test.ts
+++ b/test/execute-tools.test.ts
@@ -1,0 +1,165 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { executeTools } from '../src/index.js';
+import type { ThreadState } from '../src/entities/state.js';
+import type { ToolIntent } from '../src/entities/tool.js';
+import type { Tool } from 'langchain/tools';
+
+function createTestTool(
+        name: string,
+        handler: (args: any) => Promise<string> | string,
+): Tool {
+        return {
+                name,
+                description: 'test tool',
+                async invoke(args: any) {
+                        return handler(args);
+                },
+        } as unknown as Tool;
+}
+
+function createState(): ThreadState {
+        return {
+                thread: {
+                        usage: {prompt_tokens: 0, completion_tokens: 0, total_tokens: 0},
+                        events: [],
+                },
+        };
+}
+
+function delay(ms: number) {
+        return new Promise<void>(resolve => {
+                setTimeout(() => resolve(), ms);
+        });
+}
+
+function createConcurrencyTracker() {
+        let current = 0;
+        let max = 0;
+        return {
+                start() {
+                        current += 1;
+                        if (current > max) {
+                                max = current;
+                        }
+                },
+                end() {
+                        current = Math.max(0, current - 1);
+                },
+                get maxConcurrent() {
+                        return max;
+                },
+        };
+}
+
+describe('executeTools parallel scheduling', () => {
+        it('enforces concurrency limits and preserves event ordering', async () => {
+                const tracker = createConcurrencyTracker();
+                const slowTool = createTestTool('math_calculator', async ({expression}: {expression: string}) => {
+                        const payload = JSON.parse(expression) as {value: string; delay: number};
+                        tracker.start();
+                        await delay(payload.delay);
+                        tracker.end();
+                        return payload.value;
+                });
+
+                const intents: ToolIntent[] = [
+                        {intent: 'math_calculator', args: {expression: JSON.stringify({value: 'A', delay: 60})}, runMode: 'parallel'},
+                        {intent: 'math_calculator', args: {expression: JSON.stringify({value: 'B', delay: 20})}, runMode: 'parallel'},
+                        {intent: 'math_calculator', args: {expression: JSON.stringify({value: 'C', delay: 40})}, runMode: 'parallel'},
+                ];
+
+                const {state, summary} = await executeTools(intents, createState(), [slowTool], {
+                        concurrency: 2,
+                });
+
+                assert.equal(summary.total, 3);
+                assert.equal(summary.successCount, 3);
+                assert.equal(summary.failureCount, 0);
+                assert.ok(tracker.maxConcurrent <= 2);
+
+                const contents = state.thread.events.map(event => event.content);
+                assert.deepEqual(contents, ['A', 'B', 'C']);
+        });
+
+        it('records failures without disrupting other results', async () => {
+                const tool = createTestTool('math_calculator', async ({expression}: {expression: string}) => {
+                        if (expression === 'boom') {
+                                throw new Error('boom');
+                        }
+                        return expression;
+                });
+
+                const intents: ToolIntent[] = [
+                        {intent: 'math_calculator', args: {expression: 'ok'}, runMode: 'parallel'},
+                        {intent: 'math_calculator', args: {expression: 'boom'}, runMode: 'parallel'},
+                ];
+
+                const {state, summary} = await executeTools(intents, createState(), [tool], {
+                        concurrency: 2,
+                });
+
+                assert.equal(summary.total, 2);
+                assert.equal(summary.successCount, 1);
+                assert.equal(summary.failureCount, 1);
+                assert.equal(summary.failures.length, 1);
+
+                const failureEvent = state.thread.events.find(event => event.content.includes('Tool execution failed'));
+                assert.ok(failureEvent, 'expected failure event');
+                assert.equal(failureEvent?.metadata.status, 'error');
+        });
+
+        it('falls back to sequential execution when concurrency is disabled', async () => {
+                const tool = createTestTool('math_calculator', async ({expression}: {expression: string}) => expression);
+
+                const intents: ToolIntent[] = [
+                        {intent: 'math_calculator', args: {expression: 'first'}, runMode: 'parallel'},
+                        {intent: 'math_calculator', args: {expression: 'second'}, runMode: 'parallel'},
+                ];
+
+                const {state, summary} = await executeTools(intents, createState(), [tool], {
+                        concurrency: 1,
+                });
+
+                assert.equal(summary.successCount, 2);
+                assert.equal(summary.failureCount, 0);
+
+                const contents = state.thread.events.map(event => event.content);
+                assert.deepEqual(contents.slice(0, 2), ['first', 'second']);
+                const warning = state.thread.events.at(-1);
+                assert.equal(warning?.intent, 'parallel_execution_warning');
+        });
+
+        it('emits onResult callbacks in settlement order while preserving state order', async () => {
+                const tracker = createConcurrencyTracker();
+                const tool = createTestTool('math_calculator', async ({expression}: {expression: string}) => {
+                        const payload = JSON.parse(expression) as {value: string; delay: number};
+                        tracker.start();
+                        await delay(payload.delay);
+                        tracker.end();
+                        return payload.value;
+                });
+
+                const intents: ToolIntent[] = [
+                        {intent: 'math_calculator', args: {expression: JSON.stringify({value: 'slow', delay: 60})}, runMode: 'parallel'},
+                        {intent: 'math_calculator', args: {expression: JSON.stringify({value: 'fast', delay: 10})}, runMode: 'parallel'},
+                        {intent: 'math_calculator', args: {expression: JSON.stringify({value: 'medium', delay: 30})}, runMode: 'parallel'},
+                ];
+
+                const completionOrder: number[] = [];
+
+                const {state, summary} = await executeTools(intents, createState(), [tool], {
+                        concurrency: 3,
+                        onResult: result => {
+                                completionOrder.push(result.index);
+                        },
+                });
+
+                assert.equal(summary.total, 3);
+                assert.equal(summary.successCount, 3);
+                assert.deepEqual(completionOrder, [1, 2, 0]);
+
+                const contents = state.thread.events.map(event => event.content);
+                assert.deepEqual(contents, ['slow', 'fast', 'medium']);
+        });
+});

--- a/test/execute-tools.test.ts
+++ b/test/execute-tools.test.ts
@@ -6,160 +6,160 @@ import type { ToolIntent } from '../src/entities/tool.js';
 import type { Tool } from 'langchain/tools';
 
 function createTestTool(
-        name: string,
-        handler: (args: any) => Promise<string> | string,
+	name: string,
+	handler: (args: any) => Promise<string> | string,
 ): Tool {
-        return {
-                name,
-                description: 'test tool',
-                async invoke(args: any) {
-                        return handler(args);
-                },
-        } as unknown as Tool;
+	return {
+		name,
+		description: 'test tool',
+		async invoke(args: any) {
+			return handler(args);
+		},
+	} as unknown as Tool;
 }
 
 function createState(): ThreadState {
-        return {
-                thread: {
-                        usage: {prompt_tokens: 0, completion_tokens: 0, total_tokens: 0},
-                        events: [],
-                },
-        };
+	return {
+		thread: {
+			usage: {prompt_tokens: 0, completion_tokens: 0, total_tokens: 0},
+			events: [],
+		},
+	};
 }
 
 function delay(ms: number) {
-        return new Promise<void>(resolve => {
-                setTimeout(() => resolve(), ms);
-        });
+	return new Promise<void>(resolve => {
+		setTimeout(() => resolve(), ms);
+	});
 }
 
 function createConcurrencyTracker() {
-        let current = 0;
-        let max = 0;
-        return {
-                start() {
-                        current += 1;
-                        if (current > max) {
-                                max = current;
-                        }
-                },
-                end() {
-                        current = Math.max(0, current - 1);
-                },
-                get maxConcurrent() {
-                        return max;
-                },
-        };
+	let current = 0;
+	let max = 0;
+	return {
+		start() {
+			current += 1;
+			if (current > max) {
+				max = current;
+			}
+		},
+		end() {
+			current = Math.max(0, current - 1);
+		},
+		get maxConcurrent() {
+			return max;
+		},
+	};
 }
 
 describe('executeTools parallel scheduling', () => {
-        it('enforces concurrency limits and preserves event ordering', async () => {
-                const tracker = createConcurrencyTracker();
-                const slowTool = createTestTool('math_calculator', async ({expression}: {expression: string}) => {
-                        const payload = JSON.parse(expression) as {value: string; delay: number};
-                        tracker.start();
-                        await delay(payload.delay);
-                        tracker.end();
-                        return payload.value;
-                });
+	it('enforces concurrency limits and preserves event ordering', async () => {
+		const tracker = createConcurrencyTracker();
+		const slowTool = createTestTool('math_calculator', async ({expression}: {expression: string}) => {
+			const payload = JSON.parse(expression) as {value: string; delay: number};
+			tracker.start();
+			await delay(payload.delay);
+			tracker.end();
+			return payload.value;
+		});
 
-                const intents: ToolIntent[] = [
-                        {intent: 'math_calculator', args: {expression: JSON.stringify({value: 'A', delay: 60})}, runMode: 'parallel'},
-                        {intent: 'math_calculator', args: {expression: JSON.stringify({value: 'B', delay: 20})}, runMode: 'parallel'},
-                        {intent: 'math_calculator', args: {expression: JSON.stringify({value: 'C', delay: 40})}, runMode: 'parallel'},
-                ];
+		const intents: ToolIntent[] = [
+			{intent: 'math_calculator', args: {expression: JSON.stringify({value: 'A', delay: 60})}, runMode: 'parallel'},
+			{intent: 'math_calculator', args: {expression: JSON.stringify({value: 'B', delay: 20})}, runMode: 'parallel'},
+			{intent: 'math_calculator', args: {expression: JSON.stringify({value: 'C', delay: 40})}, runMode: 'parallel'},
+		];
 
-                const {state, summary} = await executeTools(intents, createState(), [slowTool], {
-                        concurrency: 2,
-                });
+		const {state, summary} = await executeTools(intents, createState(), [slowTool], {
+			concurrency: 2,
+		});
 
-                assert.equal(summary.total, 3);
-                assert.equal(summary.successCount, 3);
-                assert.equal(summary.failureCount, 0);
-                assert.ok(tracker.maxConcurrent <= 2);
+		assert.equal(summary.total, 3);
+		assert.equal(summary.successCount, 3);
+		assert.equal(summary.failureCount, 0);
+		assert.ok(tracker.maxConcurrent <= 2);
 
-                const contents = state.thread.events.map(event => event.content);
-                assert.deepEqual(contents, ['A', 'B', 'C']);
-        });
+		const contents = state.thread.events.map(event => event.content);
+		assert.deepEqual(contents, ['A', 'B', 'C']);
+	});
 
-        it('records failures without disrupting other results', async () => {
-                const tool = createTestTool('math_calculator', async ({expression}: {expression: string}) => {
-                        if (expression === 'boom') {
-                                throw new Error('boom');
-                        }
-                        return expression;
-                });
+	it('records failures without disrupting other results', async () => {
+		const tool = createTestTool('math_calculator', async ({expression}: {expression: string}) => {
+			if (expression === 'boom') {
+				throw new Error('boom');
+			}
+			return expression;
+		});
 
-                const intents: ToolIntent[] = [
-                        {intent: 'math_calculator', args: {expression: 'ok'}, runMode: 'parallel'},
-                        {intent: 'math_calculator', args: {expression: 'boom'}, runMode: 'parallel'},
-                ];
+		const intents: ToolIntent[] = [
+			{intent: 'math_calculator', args: {expression: 'ok'}, runMode: 'parallel'},
+			{intent: 'math_calculator', args: {expression: 'boom'}, runMode: 'parallel'},
+		];
 
-                const {state, summary} = await executeTools(intents, createState(), [tool], {
-                        concurrency: 2,
-                });
+		const {state, summary} = await executeTools(intents, createState(), [tool], {
+			concurrency: 2,
+		});
 
-                assert.equal(summary.total, 2);
-                assert.equal(summary.successCount, 1);
-                assert.equal(summary.failureCount, 1);
-                assert.equal(summary.failures.length, 1);
+		assert.equal(summary.total, 2);
+		assert.equal(summary.successCount, 1);
+		assert.equal(summary.failureCount, 1);
+		assert.equal(summary.failures.length, 1);
 
-                const failureEvent = state.thread.events.find(event => event.content.includes('Tool execution failed'));
-                assert.ok(failureEvent, 'expected failure event');
-                assert.equal(failureEvent?.metadata.status, 'error');
-        });
+		const failureEvent = state.thread.events.find(event => event.content.includes('Tool execution failed'));
+		assert.ok(failureEvent, 'expected failure event');
+		assert.equal(failureEvent?.metadata.status, 'error');
+	});
 
-        it('falls back to sequential execution when concurrency is disabled', async () => {
-                const tool = createTestTool('math_calculator', async ({expression}: {expression: string}) => expression);
+	it('falls back to sequential execution when concurrency is disabled', async () => {
+		const tool = createTestTool('math_calculator', async ({expression}: {expression: string}) => expression);
 
-                const intents: ToolIntent[] = [
-                        {intent: 'math_calculator', args: {expression: 'first'}, runMode: 'parallel'},
-                        {intent: 'math_calculator', args: {expression: 'second'}, runMode: 'parallel'},
-                ];
+		const intents: ToolIntent[] = [
+			{intent: 'math_calculator', args: {expression: 'first'}, runMode: 'parallel'},
+			{intent: 'math_calculator', args: {expression: 'second'}, runMode: 'parallel'},
+		];
 
-                const {state, summary} = await executeTools(intents, createState(), [tool], {
-                        concurrency: 1,
-                });
+		const {state, summary} = await executeTools(intents, createState(), [tool], {
+			concurrency: 1,
+		});
 
-                assert.equal(summary.successCount, 2);
-                assert.equal(summary.failureCount, 0);
+		assert.equal(summary.successCount, 2);
+		assert.equal(summary.failureCount, 0);
 
-                const contents = state.thread.events.map(event => event.content);
-                assert.deepEqual(contents.slice(0, 2), ['first', 'second']);
-                const warning = state.thread.events.at(-1);
-                assert.equal(warning?.intent, 'parallel_execution_warning');
-        });
+		const contents = state.thread.events.map(event => event.content);
+		assert.deepEqual(contents.slice(0, 2), ['first', 'second']);
+		const warning = state.thread.events.at(-1);
+		assert.equal(warning?.intent, 'parallel_execution_warning');
+	});
 
-        it('emits onResult callbacks in settlement order while preserving state order', async () => {
-                const tracker = createConcurrencyTracker();
-                const tool = createTestTool('math_calculator', async ({expression}: {expression: string}) => {
-                        const payload = JSON.parse(expression) as {value: string; delay: number};
-                        tracker.start();
-                        await delay(payload.delay);
-                        tracker.end();
-                        return payload.value;
-                });
+	it('emits onResult callbacks in settlement order while preserving state order', async () => {
+		const tracker = createConcurrencyTracker();
+		const tool = createTestTool('math_calculator', async ({expression}: {expression: string}) => {
+			const payload = JSON.parse(expression) as {value: string; delay: number};
+			tracker.start();
+			await delay(payload.delay);
+			tracker.end();
+			return payload.value;
+		});
 
-                const intents: ToolIntent[] = [
-                        {intent: 'math_calculator', args: {expression: JSON.stringify({value: 'slow', delay: 60})}, runMode: 'parallel'},
-                        {intent: 'math_calculator', args: {expression: JSON.stringify({value: 'fast', delay: 10})}, runMode: 'parallel'},
-                        {intent: 'math_calculator', args: {expression: JSON.stringify({value: 'medium', delay: 30})}, runMode: 'parallel'},
-                ];
+		const intents: ToolIntent[] = [
+			{intent: 'math_calculator', args: {expression: JSON.stringify({value: 'slow', delay: 60})}, runMode: 'parallel'},
+			{intent: 'math_calculator', args: {expression: JSON.stringify({value: 'fast', delay: 10})}, runMode: 'parallel'},
+			{intent: 'math_calculator', args: {expression: JSON.stringify({value: 'medium', delay: 30})}, runMode: 'parallel'},
+		];
 
-                const completionOrder: number[] = [];
+		const completionOrder: number[] = [];
 
-                const {state, summary} = await executeTools(intents, createState(), [tool], {
-                        concurrency: 3,
-                        onResult: result => {
-                                completionOrder.push(result.index);
-                        },
-                });
+		const {state, summary} = await executeTools(intents, createState(), [tool], {
+			concurrency: 3,
+			onResult: result => {
+				completionOrder.push(result.index);
+			},
+		});
 
-                assert.equal(summary.total, 3);
-                assert.equal(summary.successCount, 3);
-                assert.deepEqual(completionOrder, [1, 2, 0]);
+		assert.equal(summary.total, 3);
+		assert.equal(summary.successCount, 3);
+		assert.deepEqual(completionOrder, [1, 2, 0]);
 
-                const contents = state.thread.events.map(event => event.content);
-                assert.deepEqual(contents, ['slow', 'fast', 'medium']);
-        });
+		const contents = state.thread.events.map(event => event.content);
+		assert.deepEqual(contents, ['slow', 'fast', 'medium']);
+	});
 });


### PR DESCRIPTION
## Summary
- refactor tool execution to support parallel batches with configurable concurrency, scheduler hooks, result streaming, and sequential fallback warnings
- extend ToolIntent metadata and update documentation to describe new options and return telemetry from executeTools
- add unit tests verifying concurrency limits, deterministic ordering, error aggregation, and onResult callback behaviour

## Testing
- npm run build
- npx tsx --test --env-file=.env.test test/execute-tools.test.ts
- npm test *(fails: missing OPENAI_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68e45e87caf4832881b70053680d71ce